### PR TITLE
Fix skylake installation jobscript

### DIFF
--- a/jobscripts/peregrine/installjob_skylake.sh
+++ b/jobscripts/peregrine/installjob_skylake.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 #SBATCH --nodes=1
 #SBATCH --tasks-per-node=4
-#SBATCH --cpus-per-task=2
-#SBATCH --mem=64G
+#SBATCH --cpus-per-task=3
+#SBATCH --mem=120G
 #SBATCH --time=12:00:00
 #SBATCH --partition=gpu
 #SBATCH --gres=gpu:v100:1

--- a/jobscripts/peregrine/installjob_skylake.sh
+++ b/jobscripts/peregrine/installjob_skylake.sh
@@ -4,8 +4,8 @@
 #SBATCH --cpus-per-task=2
 #SBATCH --mem=64G
 #SBATCH --time=12:00:00
-#SBATCH --partition=vulture
-#SBATCH --constraint=12cores
+#SBATCH --partition=gpu
+#SBATCH --gres=gpu:v100:1
 
 # Install package
 ./eb_install.sh $@


### PR DESCRIPTION
The only Skylake based machines left are the V100 GPU nodes. This change will select these for the software installation job.