### PR TITLE
Update Mellanox repo URL for build container

### DIFF
--- a/singularity/centos7/repo_mellanox_hpc.repo
+++ b/singularity/centos7/repo_mellanox_hpc.repo
@@ -1,5 +1,5 @@
 [Mellanox-local] 
 name=Local Mellanox repository
 enabled=1
-baseurl=https://downloads.whamcloud.com/public/lustre/lustre-2.12.3-ib/MOFED-4.7-1.0.0.1/el7.7.1908/client
+baseurl=https://downloads.whamcloud.com/public/lustre/lustre-2.12.8-ib/MOFED-4.9-4.1.7.0/el7.9.2009/client
 gpgcheck=0


### PR DESCRIPTION
We were still using a repo with older versions (for older Lustre clients / CentOS versions), the new one matches with what we use on Peregrine nodes.