### PR TITLE
Save eb log on failures

### DIFF
--- a/jobscripts/peregrine/eb_install.sh
+++ b/jobscripts/peregrine/eb_install.sh
@@ -14,5 +14,6 @@ if [ -c /dev/nvidia0 ]; then
     SINGOPTS="--nv $SINGOPTS"
 fi
 singularity shell $SINGOPTS /home/$USER/easybuild/cit-hpc-easybuild/singularity/centos7/buildhost.simg  < $TMPSCRIPT
+ec=$?
 rm $TMPSCRIPT
-
+exit $ec

--- a/jobscripts/peregrine/install_easyconfig.sh
+++ b/jobscripts/peregrine/install_easyconfig.sh
@@ -79,7 +79,7 @@ if [ \$ec -ne 0 ]
 then
   # Copy the EasyBuild log from the temporary build directory to the job's directory
   eb_log_src=\$(./eb_install.sh --last-log)
-  eb_log_dst="./bla-haswell-\${SLURM_JOB_ID}-eb.log"
+  eb_log_dst="./${softwarename}-${arch}-\${SLURM_JOB_ID}-eb.log"
   echo "Software installation failed, copying EasyBuild log to \$eb_log_dst"
   cp "\$eb_log_src" "\$eb_log_dst"
 fi

--- a/jobscripts/peregrine/install_easyconfig.sh
+++ b/jobscripts/peregrine/install_easyconfig.sh
@@ -74,9 +74,21 @@ EOF
      echo "./eb_install.sh $easyconfig $eb_options" >> $jobscript
      # Write footer for jobscript
 cat << EOF >> $jobscript
+ec=\$?
+if [ \$ec -ne 0 ] 
+then
+  # Copy the EasyBuild log from the temporary build directory to the job's directory
+  eb_log_src=\$(./eb_install.sh --last-log)
+  eb_log_dst="./bla-haswell-\${SLURM_JOB_ID}-eb.log"
+  echo "Software installation failed, copying EasyBuild log to \$eb_log_dst"
+  cp "\$eb_log_src" "\$eb_log_dst"
+fi
 
 # Update module cache
 ./update_lmod_cache.sh
+
+# Set the exit code of the job to the exit code of EasyBuild 
+exit \$ec
 EOF
   # Submit jobscript to Slurm
   sbatch $jobscript


### PR DESCRIPTION
This will check the exit code of the `eb` command, and in case of failures it will copy the eb log to the working directory of the job. Furthermore, it will set the exit code of the job to the exit code of the `eb` command, to make sure that the job status is also set to `FAILED` in case of errors.