### PR TITLE
Script to list the software in the architecture stacks for comparison.

### DIFF
--- a/scripts/list_sw/list_software.sh
+++ b/scripts/list_sw/list_software.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+archs="amd/zen amd/zen3 intel/icelake intel/skylake_avx512"
+for arch in $archs; do
+  outfile=$( echo $arch | tr '/' '_').out
+  ls -d /cvmfs/hpc.rug.nl/versions/2023.01/rocky8/x86_64/$arch/software/*/* | sort | awk -F '/' '{print $11 "-" $12}'  > $outfile
+done


### PR DESCRIPTION
It is stored in a separate directory to prevent the output from cluttering another location.