### PR TITLE
Allow apptainer easyblock to copy/extract source files to build directory

### DIFF
--- a/easyblocks/generic/apptainer.py
+++ b/easyblocks/generic/apptainer.py
@@ -61,7 +61,7 @@ class Apptainer(Binary):
 
     def extract_step(self):
         """No extract step"""
-        pass
+        super(Apptainer, self).extract_step()
 
     def install_step(self):
         # Set the installation command


### PR DESCRIPTION
Required if the specific recipe uses an apptainer .def file instead of an online image.