### PR TITLE
Add Valgrind

### DIFF
--- a/easystacks/habrok-2023.01-cvmfs.yml
+++ b/easystacks/habrok-2023.01-cvmfs.yml
@@ -278,3 +278,6 @@ easyconfigs:
   - PyTorch-2.1.2-foss-2022b.eb
   - GATE-9.2-foss-2022a.eb
   - MRtrix-3.0.3-foss-2021a.eb
+  - Valgrind-3.20.0-gompi-2022a.eb
+  - Valgrind-3.21.0-gompi-2022b.eb
+  - Valgrind-3.21.0-gompi-2023a.eb


### PR DESCRIPTION
Adds Valgrind versions 3.20 for `gompi-2022a` and 3.21 for `gompi-2022b` and `gompi-2023a`.