### PR TITLE
Add Gurobi v11.0.0 GCCcore-12.2.0

### DIFF
--- a/easyblocks/g/gurobi.py
+++ b/easyblocks/g/gurobi.py
@@ -77,7 +77,7 @@ class EB_Gurobi(Tarball):
             copy_file(self.orig_license_file, self.license_file)
 
         if get_software_root('Python'):
-            # Python component installation method changed in from v11.0.0
+            # Python component installation method changed in v11.0.0 to use pip install
             if LooseVersion(self.version) < LooseVersion("11.0.0"):
                 run_cmd("python setup.py install --prefix=%s" % self.installdir)
             else:

--- a/easyblocks/g/gurobi.py
+++ b/easyblocks/g/gurobi.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+##
+# Copyright 2009-2023 Ghent University
+#
+# This file is part of EasyBuild,
+# originally created by the HPC team of Ghent University (http://ugent.be/hpc/en),
+# with support of Ghent University (http://ugent.be/hpc),
+# the Flemish Supercomputer Centre (VSC) (https://vscentrum.be/nl/en),
+# Flemish Research Foundation (FWO) (http://www.fwo.be/en)
+# and the Department of Economy, Science and Innovation (EWI) (http://www.ewi-vlaanderen.be/en).
+#
+# https://github.com/easybuilders/easybuild
+#
+# EasyBuild is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation v2.
+#
+# EasyBuild is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with EasyBuild.  If not, see <http://www.gnu.org/licenses/>.
+##
+"""
+EasyBuild support for installing Gurobi, implemented as an easyblock
+
+@author: Bob Dröge (University of Groningen)
+@author: Samuel Moors (Vrije Universiteit Brussel)
+"""
+import os
+
+from easybuild.easyblocks.generic.pythonpackage import det_pylibdir
+from easybuild.easyblocks.generic.tarball import Tarball
+from easybuild.framework.easyconfig import CUSTOM
+from easybuild.tools.build_log import EasyBuildError
+from easybuild.tools.filetools import copy_file
+from easybuild.tools.modules import get_software_root
+from easybuild.tools.run import run_cmd
+from easybuild.tools import LooseVersion
+
+
+class EB_Gurobi(Tarball):
+    """Support for installing linux64 version of Gurobi."""
+
+    @staticmethod
+    def extra_options(extra_vars=None):
+        """Define extra options for Gurobi"""
+        extra = {
+            'copy_license_file': [True, "Copy license_file to installdir", CUSTOM],
+        }
+        return Tarball.extra_options(extra_vars=extra)
+
+    def __init__(self, *args, **kwargs):
+        """Easyblock constructor, define custom class variables specific to Gurobi."""
+        super(EB_Gurobi, self).__init__(*args, **kwargs)
+
+        # make sure license file is available
+        self.orig_license_file = self.cfg['license_file']
+        if self.orig_license_file is None:
+            self.orig_license_file = os.getenv('EB_GUROBI_LICENSE_FILE', None)
+
+        if self.cfg['copy_license_file']:
+            self.license_file = os.path.join(self.installdir, 'gurobi.lic')
+        else:
+            self.license_file = self.orig_license_file
+
+    def install_step(self):
+        """Install Gurobi and license file."""
+        super(EB_Gurobi, self).install_step()
+
+        if self.cfg['copy_license_file']:
+            if self.orig_license_file is None or not os.path.exists(self.orig_license_file):
+                raise EasyBuildError("No existing license file specified: %s", self.orig_license_file)
+
+            copy_file(self.orig_license_file, self.license_file)
+
+        if get_software_root('Python'):
+            # Python component installation method changed in from v11.0.0
+            if LooseVersion(self.version) < LooseVersion("11.0.0"):
+                run_cmd("python setup.py install --prefix=%s" % self.installdir)
+            else:
+                run_cmd("python -m pip install --find-links=%s --no-index --target=%s gurobipy" % (self.builddir, self.installdir))
+
+    def sanity_check_step(self):
+        """Custom sanity check for Gurobi."""
+        custom_paths = {
+            'files': ['bin/%s' % f for f in ['grbprobe', 'grbtune', 'gurobi_cl', 'gurobi.sh']],
+            'dirs': ['matlab'],
+        }
+
+        custom_commands = [
+            "gurobi_cl --help",
+            'test -f $GRB_LICENSE_FILE',
+        ]
+
+        if get_software_root('Python'):
+            custom_commands.append("python -c 'import gurobipy'")
+
+        super(EB_Gurobi, self).sanity_check_step(custom_commands=custom_commands, custom_paths=custom_paths)
+
+    def make_module_extra(self):
+        """Custom extra module file entries for Gurobi."""
+        txt = super(EB_Gurobi, self).make_module_extra()
+        txt += self.module_generator.set_environment('GUROBI_HOME', self.installdir)
+        txt += self.module_generator.set_environment('GRB_LICENSE_FILE', self.license_file)
+
+        if get_software_root('Python'):
+            txt += self.module_generator.prepend_paths('PYTHONPATH', det_pylibdir())
+
+        txt += self.module_generator.prepend_paths('MATLABPATH', 'matlab')
+
+        return txt

--- a/easyconfigs/g/Gurobi/Gurobi-11.0.0-GCCcore-12.3.0.eb
+++ b/easyconfigs/g/Gurobi/Gurobi-11.0.0-GCCcore-12.3.0.eb
@@ -1,0 +1,52 @@
+name = 'Gurobi'
+version = '11.0.0'
+
+homepage = 'https://www.gurobi.com'
+description = """The Gurobi Optimizer is a state-of-the-art solver for mathematical programming.
+The solvers in the Gurobi Optimizer were designed from the ground up to exploit modern
+architectures and multi-core processors, using the most advanced implementations of the
+latest algorithms."""
+
+toolchain = {'name': 'GCCcore', 'version': '12.3.0'}
+
+source_urls = [
+    'https://packages.gurobi.com/%(version_major_minor)s/',
+    'https://pypi.python.org/packages/source/%(nameletter)s/gurobipy',
+]
+sources = [
+    {
+        'filename': '%(namelower)s%(version)s_linux64.tar.gz',
+    },
+    {
+        'filename': 'gurobipy-%(version)s-cp311-cp311-manylinux2014_%(arch)s.manylinux_2_17_%(arch)s.whl',
+        'extract_cmd': 'cp %s %(builddir)s',
+    }
+]
+patches = ['%(name)s-11.0.0_use-eb-python-gurobi-shell.patch']
+checksums = [
+    {'gurobi11.0.0_linux64.tar.gz': '6a1ec7499b230aea0542bc893bf0642ae8ce983dd5ef0c37cb3a253d827ce634'},
+    {'gurobipy-11.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl':
+     'a98abda1cb45f548fff17370eb30cc6e187d04edc5d9984a68d194491598a993'},
+    {'Gurobi-11.0.0_use-eb-python-gurobi-shell.patch':
+     'ae641470aad41c1db71eb62344472eb645310a76ca8a310e32e88a4f7a3b0eb9'},
+]
+
+builddependencies = [
+    ('binutils', '2.40'),
+]
+
+dependencies = [
+    ('Python', '3.11.3'),
+]
+
+# remove bundled Python interpreter in favour of the dependency in EB
+postinstallcmds = ['rm %(installdir)s/bin/python*']
+
+# license is mandatory for installation
+license_file = HOME + '/licenses/%(name)s.lic'
+
+modloadmsg = """Gurobi shell based on Python %(pyver)s can be launched with command `gurobi.sh`
+Gurobi Python Interface can be loaded in Python %(pyver)s with 'import gurobipy'
+"""
+
+moduleclass = 'math'

--- a/easyconfigs/g/Gurobi/Gurobi-11.0.0_use-eb-python-gurobi-shell.patch
+++ b/easyconfigs/g/Gurobi/Gurobi-11.0.0_use-eb-python-gurobi-shell.patch
@@ -1,0 +1,15 @@
+--- /a/bin/gurobi.sh	2023-11-22 03:21:59.000000000 +0100
++++ /b/bin/gurobi.sh	2024-01-29 13:37:17.691447579 +0100
+@@ -7,10 +7,6 @@
+   echo
+ fi
+ 
+-PATH=$GUROBI_HOME/bin:$PATH;export PATH
+-LD_LIBRARY_PATH=$GUROBI_HOME/lib:$LD_LIBRARY_PATH;export LD_LIBRARY_PATH
+-PYTHONHOME=$GUROBI_HOME;export PYTHONHOME
++PYTHONSTARTUP=$EBROOTGUROBI/lib/gurobi.py;export PYTHONSTARTUP
+ 
+-PYTHONSTARTUP=$PYTHONHOME/lib/gurobi.py;export PYTHONSTARTUP
+-
+-$PYTHONHOME/bin/python3.11 "$@"
++$EBROOTPYTHON/bin/python "$@"


### PR DESCRIPTION
From v11.0.0 Gurobi has changed the way the Python component is installed. Where before installation happened via a `setup.py` file that was bundled in with the source tarball now the contents of this file simply raise an exception and point the user to install via `pip`.

Because of this, it's now necessary to fetch the appropriate wheel, and then run the `pip install` command on said wheel. Gurobi is installed via a custom easyblock file, which I edited from the easybuild-easyblocks repo (and that was originally made by @bedroge). The installation step of the original easyblock file needed to be changed to check if the target installation is >=11.0.0, and if so, the installation must then be handled accordingly.

I think I covered all edge cases, and I'm able to start the gurobi shell and import the module (but haven't ingested the installation yet, hence the draft PR), in case I'm overlooking something.