### PR TITLE
Add hook for changing `-march=native` to `-march=x86-64-v3` in `Makeconf` file of R installations

### DIFF
--- a/hooks/habrok.py
+++ b/hooks/habrok.py
@@ -212,7 +212,7 @@ def pre_module_hook(self, *args, **kwargs):
 
 def pre_install_hook(self, *args, **kwargs):
     # R Packages: temporarily revert the -march=x86-64-v3 flags in the R installation back to -march=native
-    # by making a symlink $HOME/.R/Makevars -> $EBROOTR/lib64/R/etc/Makeconf.bak.
+    # by making a symlink $HOME/.R/Makevars -> $EBROOTR/lib64/R/etc/Makeconf.orig.eb.
     # (and undo this later on in a post-install hook)
     if self.cfg['easyblock'] == 'RPackage':
         add_symlink_to_original_R_makevars(self.log)
@@ -228,7 +228,7 @@ def add_symlink_to_original_R_makevars(log):
         r_user_dir = os.path.join(os.path.expanduser('~'), '.R')
         r_user_makevars = os.path.join(r_user_dir, 'Makevars')
         r_install_dir = os.path.expandvars('$EBROOTR')
-        r_orig_makeconf = os.path.join(r_install_dir, 'lib64', 'R', 'etc', 'Makeconf.bak')
+        r_orig_makeconf = os.path.join(r_install_dir, 'lib64', 'R', 'etc', 'Makeconf.orig.eb')
         if os.path.exists(os.path.join(r_user_dir, 'Makevars')):
             raise EasyBuildError("Existing Makevars file found in %s, please remove it!" % r_user_dir)
         if not os.path.exists(r_orig_makeconf):

--- a/hooks/habrok.py
+++ b/hooks/habrok.py
@@ -106,6 +106,9 @@ def parse_hook(self):
 
 
 def pre_extensions_hook(self, *args, **kwargs):
+    # Before installing R package bundles, create a symlink to the original Makevars file.
+    # This ensures that -march=native is used for these installations.
+    # The symlink will be removed again with a post_extensions hook.
     if self.cfg['easyblock'] == 'Bundle':
         if self.cfg['exts_defaultclass'] == 'RPackage':
             add_symlink_to_original_R_makevars(self.log)
@@ -119,6 +122,8 @@ def post_extensions_hook(self, *args, **kwargs):
         apply_regex_substitutions(os.path.join(self.installdir, 'lib64', 'R', 'etc', 'Makeconf'), [
             (r'(.*FLAGS = .*)(-march=native)(.*)', r'\1-march=x86-64-v3\3'),
         ])
+
+    # For R package bundles, remove the symlink again that was created by the pre_extensions hook.
     if self.cfg['easyblock'] == 'Bundle':
         if self.cfg['exts_defaultclass'] == 'RPackage':
             remove_symlink_to_original_R_makevars(self.log)

--- a/hooks/habrok.py
+++ b/hooks/habrok.py
@@ -109,7 +109,7 @@ def post_extensions_hook(self, *args, **kwargs):
     # Replace the -march=native flags in the Makeconf file of R installations by -march=x86-64-v3.
     # This ensures that user-installed extensions are compatible with all nodes.
     if self.name == 'R':
-        self.log.info("[post-extensions hook] Replace -march=native by -march=x86-64-v3 in etc/Makeconf")
+        self.log.info("[post-extensions hook] Replace -march=native by -march=x86-64-v3 in lib64/R/etc/Makeconf")
         apply_regex_substitutions(os.path.join(self.installdir, 'lib64', 'R', 'etc', 'Makeconf'), [
             (r'(.*FLAGS = .*)(-march=native)(.*)', r'\1-march=x86-64-v3\3'),
         ])


### PR DESCRIPTION
~TODO: add another hook that temporarily reverts this change for easyconfigs that install R extensions, e.g. R-bundle-CRAN.~
Done in https://github.com/rug-cit-hpc/cit-hpc-easybuild/pull/59/commits/12bfd10a0ce08d0dc1cdbb4a368c334d5601d5b0.

This adds a post-extensions hook for the installation of R itself, which will replace `-march=native` by `-march=x86-64-v3` in its `Makeconf` file when it's done with installing the included extensions. The original file will be copied to `Makeconf.bak`.

To make sure that our EB-installed R packages are still properly optimized, it also adds a pre-install hook that applies to any easyconfig with `easyblock = RPackage`, and this hook basically reverts that change temporarily by making a symlink `$HOME/.R/Makevars -> $EBROOTR/lib64/R/etc/Makeconf.bak`, i.e. to the original `Makeconf` file of the corresponding R installation. As the user file takes precedence, it will override the values from the `Makeconf` file in the R installation. A corresponding post-install hook will remove the symlink again.
Note that the pre-install hook will error out if it finds an existing `$HOME/.R/Makevars`, as it would otherwise overwrite it, and it's somewhat dangerous anyway to have such a file in your home directory.

TODO: test it on a bundle, as I'm not sure if it will call the hook in that case (extensions don't seem to call the pre/post-install).