### PR TITLE
ITK-SNAP

### DIFF
--- a/easyconfigs/i/ITK-SNAP/ITK-SNAP-4.0.0-foss-2021b.eb.WiP
+++ b/easyconfigs/i/ITK-SNAP/ITK-SNAP-4.0.0-foss-2021b.eb.WiP
@@ -8,7 +8,7 @@ version = '4.0.0'
 homepage = 'http://www.itksnap.org/'
 description = """ITK-SNAP is a software application used to segment structures in 3D medical images. It is the product of a decade-long collaboration between Paul Yushkevich, Ph.D., of the Penn Image Computing and Science Laboratory (PICSL) at the University of Pennsylvania, and Guido Gerig, Ph.D., of the Scientific Computing and Imaging Institute (SCI) at the University of Utah, whose vision was to create a tool that would be dedicated to a specific function, segmentation, and would be easy to use and learn. ITK-SNAP is free, open-source, and multi-platform."""
 
-toolchain = {'name': 'foss', 'version': '2022b'}
+toolchain = {'name': 'foss', 'version': '2021b'}
 toolchainopts = {'pic': True, 'cstd': 'c++11'}
 
 #github_account = 'pyushkevich'
@@ -26,16 +26,16 @@ sources = [
 }]
 
 builddependencies = [
-    ('CMake', '3.24.3'),
+    ('CMake', '3.22.1', '', ('GCCcore', '11.2.0')),
 ]
 
 # start_dir = ''
 
 dependencies = [
     ('ITK', '5.2.1'),
-    ('VTK', '9.2.6'),
-    ('Qt5', '5.15.7'),
-    ('Eigen', '3.4.0'),
+    ('VTK', '9.1.0'),
+    ('Qt5', '5.15.2', '', ('GCCcore', '11.2.0')),
+    ('Eigen', '3.4.0', '', ('GCCcore', '11.2.0')),
 ]
 
 separate_build_dir = True

--- a/easyconfigs/i/ITK-SNAP/ITK-SNAP-4.0.0-foss-2021b.eb.WiP
+++ b/easyconfigs/i/ITK-SNAP/ITK-SNAP-4.0.0-foss-2021b.eb.WiP
@@ -8,7 +8,7 @@ version = '4.0.0'
 homepage = 'http://www.itksnap.org/'
 description = """ITK-SNAP is a software application used to segment structures in 3D medical images. It is the product of a decade-long collaboration between Paul Yushkevich, Ph.D., of the Penn Image Computing and Science Laboratory (PICSL) at the University of Pennsylvania, and Guido Gerig, Ph.D., of the Scientific Computing and Imaging Institute (SCI) at the University of Utah, whose vision was to create a tool that would be dedicated to a specific function, segmentation, and would be easy to use and learn. ITK-SNAP is free, open-source, and multi-platform."""
 
-toolchain = {'name': 'foss', 'version': '2021b'}
+toolchain = {'name': 'foss', 'version': '2022b'}
 toolchainopts = {'pic': True, 'cstd': 'c++11'}
 
 #github_account = 'pyushkevich'
@@ -26,16 +26,16 @@ sources = [
 }]
 
 builddependencies = [
-    ('CMake', '3.22.1', '', ('GCCcore', '11.2.0')),
+    ('CMake', '3.24.3'),
 ]
 
 # start_dir = ''
 
 dependencies = [
     ('ITK', '5.2.1'),
-    ('VTK', '9.1.0'),
-    ('Qt5', '5.15.2', '', ('GCCcore', '11.2.0')),
-    ('Eigen', '3.4.0', '', ('GCCcore', '11.2.0')),
+    ('VTK', '9.2.6'),
+    ('Qt5', '5.15.7'),
+    ('Eigen', '3.4.0'),
 ]
 
 separate_build_dir = True

--- a/easyconfigs/i/ITK-SNAP/ITK-SNAP-4.2.0-c3d.patch
+++ b/easyconfigs/i/ITK-SNAP/ITK-SNAP-4.2.0-c3d.patch
@@ -1,0 +1,545 @@
+index 1e0fd92..3e527d5 100644
+--- Submodules/c3d/CMakeLists.txt
++++ Submodules/c3d/CMakeLists.txt
+@@ -14,14 +14,14 @@ endif(COMMAND cmake_policy)
+ INCLUDE(CMake/PYVersion.cmake)
+ 
+ # Set the semantic version and version date
+-VERSION_VARS(1 4 0 "" "20220519" "May 19, 2022")
++VERSION_VARS(1 4 1 "" "20240318" "March 18, 2024")
+ 
+ # Enable languages
+ ENABLE_LANGUAGE(C)
+ ENABLE_LANGUAGE(CXX)
+ 
+ # Specify the C++ standard
+-SET(CMAKE_CXX_STANDARD 11)
++SET(CMAKE_CXX_STANDARD 17)
+ SET(CMAKE_CXX_STANDARD_REQUIRED True)
+ 
+ # Option allowing to build c3d as a subproject of another project
+@@ -72,6 +72,7 @@ IF(NOT CONVERT3D_BUILD_AS_SUBPROJECT)
+     ITKLabelVoting
+     ITKLevelSets
+     ITKMathematicalMorphology
++    ITKNIFTI
+     ITKRegistrationCommon
+     ITKSmoothing
+     ITKStatistics
+diff --git Submodules/c3d/ConvertImageND.cxx Submodules/c3d/ConvertImageND.cxx
+index 4b97537..9b9a56e 100644
+--- Submodules/c3d/ConvertImageND.cxx
++++ Submodules/c3d/ConvertImageND.cxx
+@@ -3021,7 +3021,7 @@ ::PrintMatrix(std::ostream &sout, vnl_matrix<double> mat, const char *fmt, const
+     sout << prefix;
+     for(size_t j = 0; j < mat.columns(); j++)
+       {
+-      sprintf(buffer, fmt, mat(i,j));
++      snprintf(buffer, sizeof(buffer), fmt, mat(i,j));
+       sout << buffer;
+       }
+     sout << endl;
+@@ -3418,14 +3418,14 @@ ::WriteMultiple(int argc, char *argv[], int n_comp, const char *command)
+ {
+   // Check if the argument is a printf pattern
+   char buffer[(FILENAME_MAX+1)*n_comp];
+-  sprintf(buffer, argv[1],0);
++  snprintf(buffer, sizeof(buffer), argv[1],0);
+   if (strcmp(buffer, argv[1]))
+     {
+     // A pattern is specified. For each image on the stack, use pattern
+     for(size_t i = 0; i < m_ImageStack.size(); i+= n_comp)
+       {
+       WriteImage<TPixel, VDim> adapter(this);
+-      sprintf(buffer, argv[1], i / n_comp);
++      snprintf(buffer, sizeof(buffer), argv[1], i / n_comp);
+       if(n_comp == 1)
+         adapter(buffer, true, i);
+       else 
+diff --git Submodules/c3d/adapters/ExportPatches.cxx Submodules/c3d/adapters/ExportPatches.cxx
+index ef9849a..6f20f96 100644
+--- Submodules/c3d/adapters/ExportPatches.cxx
++++ Submodules/c3d/adapters/ExportPatches.cxx
+@@ -158,7 +158,7 @@ ::operator() (const char *out_file, const SizeType &radius, double sample_freque
+   typedef vnl_matrix_fixed<double, VDim+1, VDim+1> Mat44;
+   Mat44 R;
+   Mat44 D = mask->GetVoxelSpaceToRASPhysicalSpaceMatrix().GetVnlMatrix();
+-  Mat44 Dinv = vnl_inverse<double>(D);
++  Mat44 Dinv = vnl_inverse<double>(D.as_matrix());
+ 
+   R.set_identity();
+ 
+diff --git Submodules/c3d/adapters/MatchBoundingBoxes.cxx Submodules/c3d/adapters/MatchBoundingBoxes.cxx
+index 17efdb2..787cd20 100644
+--- Submodules/c3d/adapters/MatchBoundingBoxes.cxx
++++ Submodules/c3d/adapters/MatchBoundingBoxes.cxx
+@@ -45,7 +45,7 @@ ::operator() ()
+   // bounding boxes of the two images are exactly the same
+   // O1 - S1 * D * [0.5] = O2 - S2 * D * [0.5]
+ 
+-  vnl_matrix<double> dir = t->GetDirection().GetVnlMatrix();
++  vnl_matrix<double> dir = t->GetDirection().GetVnlMatrix().as_matrix();
+   vnl_vector<double> v(VDim); v.fill(0.5);
+   vnl_vector<double> Dv = dir * v;
+   vnl_vector<double> orig(VDim), spc(VDim);
+diff --git Submodules/c3d/adapters/PrintImageInfo.cxx Submodules/c3d/adapters/PrintImageInfo.cxx
+index 845c17b..9659024 100644
+--- Submodules/c3d/adapters/PrintImageInfo.cxx
++++ Submodules/c3d/adapters/PrintImageInfo.cxx
+@@ -180,7 +180,7 @@ ::operator() (bool full)
+     c->sout() << " bb = {[" << bb0 << "], [" << bb1 << "]}; ";
+     c->sout() << " vox = " << image->GetSpacing() << "; ";
+     c->sout() << " range = [" << iMin << ", " << iMax << "]; ";
+-    c->sout() << " orient = " << GetRAICodeFromDirectionMatrix(image->GetDirection().GetVnlMatrix()) << endl;
++    c->sout() << " orient = " << GetRAICodeFromDirectionMatrix(image->GetDirection().GetVnlMatrix().as_ref()) << endl;
+     c->sout() << endl;
+     }
+   else
+@@ -191,14 +191,14 @@ ::operator() (bool full)
+     c->sout() << "  Voxel Spacing      : " << image->GetSpacing() << endl;
+     c->sout() << "  Intensity Range    : [" << iMin << ", " << iMax << "]" << endl;
+     c->sout() << "  Mean Intensity     : " << iMean << endl;
+-    c->sout() << "  Canon. Orientation : " << GetRAICodeFromDirectionMatrix(image->GetDirection().GetVnlMatrix()) << endl;
++    c->sout() << "  Canon. Orientation : " << GetRAICodeFromDirectionMatrix(image->GetDirection().GetVnlMatrix().as_ref()) << endl;
+     c->sout() << "  Direction Cos Mtx. : " << endl;
+-    c->PrintMatrix(c->sout(), image->GetDirection().GetVnlMatrix());
++    c->PrintMatrix(c->sout(), image->GetDirection().GetVnlMatrix().as_ref());
+ 
+     // Print NIFTI s-form matrix (check against freesurfer's MRIinfo)
+     c->sout() << "  Voxel->RAS x-form  : " << endl;
+     c->PrintMatrix(c->sout(), 
+-      image->GetVoxelSpaceToRASPhysicalSpaceMatrix().GetVnlMatrix(), "%12.5f ", "    ");
++      image->GetVoxelSpaceToRASPhysicalSpaceMatrix().GetVnlMatrix().as_ref(), "%12.5f ", "    ");
+ 
+     //
+     // Print metadata
+@@ -209,8 +209,7 @@ ::operator() (bool full)
+       {
+       // Get the metadata as a generic object
+       string key = itMeta->first, v_string;
+-      itk::SpatialOrientation::ValidCoordinateOrientationFlags v_oflags = 
+-        itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_INVALID;
++      auto v_oflags = itk::SpatialOrientationEnums::ValidCoordinateOrientations::ITK_COORDINATE_ORIENTATION_INVALID;
+ 
+       if(itk::ExposeMetaData<string>(mdd, key, v_string))
+         {
+diff --git Submodules/c3d/adapters/ResliceImage.cxx Submodules/c3d/adapters/ResliceImage.cxx
+index c6b04f9..79b59db 100644
+--- Submodules/c3d/adapters/ResliceImage.cxx
++++ Submodules/c3d/adapters/ResliceImage.cxx
+@@ -157,8 +157,8 @@ ::operator() (string format, string fn_tran)
+   *c->verbose << "  Affine Transform: " << endl;
+   vnl_matrix<double> amat(VDim+1, VDim+1, 0); 
+   vnl_vector<double> atmp(VDim+1, 0); 
+-  amat.update(atran->GetMatrix().GetVnlMatrix(), 0, 0);
+-  atmp.update(atran->GetOffset().GetVnlVector(), 0);
++  amat.update(atran->GetMatrix().GetVnlMatrix().as_ref(), 0, 0);
++  atmp.update(atran->GetOffset().GetVnlVector().as_ref(), 0);
+   amat.set_column(VDim, atmp);
+   c->PrintMatrix(*c->verbose, amat, "%12.5f ", "    ");
+ 
+diff --git Submodules/c3d/adapters/SetSform.cxx Submodules/c3d/adapters/SetSform.cxx
+index 3b49c77..a3f47c0 100644
+--- Submodules/c3d/adapters/SetSform.cxx
++++ Submodules/c3d/adapters/SetSform.cxx
+@@ -70,7 +70,7 @@ ::operator() (string fn_tran)
+   itk::Matrix<double,VDim+1,VDim+1> matrix;
+   MyReadMatrix<VDim>(fn_tran.c_str(), matrix);
+   vnl_matrix<double> mat(VDim+1,VDim+1,0.0);
+-  mat.update( matrix.GetVnlMatrix());
++  mat.update( matrix.GetVnlMatrix().as_matrix());
+ 
+   // Set the matrix
+   img->SetVoxelSpaceToRASPhysicalSpaceMatrix( mat );
+diff --git Submodules/c3d/adapters/SwapDimensions.cxx Submodules/c3d/adapters/SwapDimensions.cxx
+index 53bb3b7..9b558b4 100644
+--- Submodules/c3d/adapters/SwapDimensions.cxx
++++ Submodules/c3d/adapters/SwapDimensions.cxx
+@@ -91,7 +91,7 @@ ValidCoordinateOrientationFlags GetOrientationFlagFromString(const std::string &
+     return emap[code];
+ 
+   else
+-    return ITK_COORDINATE_ORIENTATION_INVALID;
++    return itk::SpatialOrientationEnums::ValidCoordinateOrientations::ITK_COORDINATE_ORIENTATION_INVALID;
+ }
+ 
+ template <class TPixel, unsigned int VDim>
+@@ -115,7 +115,7 @@ class SwapDimensions_OrientWorker<TPixel, 3>
+     {
+     // Convert the orientation code to an ITK 
+     ValidCoordinateOrientationFlags oflag = GetOrientationFlagFromString(code);
+-    if(oflag == itk::SpatialOrientation::ITK_COORDINATE_ORIENTATION_INVALID)
++    if(oflag == itk::SpatialOrientationEnums::ValidCoordinateOrientations::ITK_COORDINATE_ORIENTATION_INVALID)
+       throw ConvertException("Orientation flag %s is not valid", code.c_str());
+ 
+     // Create the filter
+diff --git Submodules/c3d/itkextras/itkGaussianInterpolateImageFunction.h Submodules/c3d/itkextras/itkGaussianInterpolateImageFunction.h
+index 4765dfc..7b1d468 100644
+--- Submodules/c3d/itkextras/itkGaussianInterpolateImageFunction.h
++++ Submodules/c3d/itkextras/itkGaussianInterpolateImageFunction.h
+@@ -90,7 +90,7 @@ class ITK_EXPORT GaussianInterpolateImageFunction :
+     }
+ 
+   /** Set input */
+-  virtual void SetInputImage(const TInputImage *img)
++  virtual void SetInputImage(const TInputImage *img) ITK_OVERRIDE
+     {
+     // Call parent method
+     Superclass::SetInputImage(img);
+@@ -117,7 +117,7 @@ class ITK_EXPORT GaussianInterpolateImageFunction :
+    * ImageFunction::IsInsideBuffer() can be used to check bounds before
+    * calling the method. */
+   virtual OutputType EvaluateAtContinuousIndex( 
+-    const ContinuousIndexType & index ) const
++    const ContinuousIndexType & index ) const ITK_OVERRIDE
+     {
+     return EvaluateAtContinuousIndex(index, NULL);
+     }
+@@ -199,10 +199,22 @@ class ITK_EXPORT GaussianInterpolateImageFunction :
+ 
+     }
+ 
++  /** This is definition from ITKv4 Compatible mode. Change this in the future when needed*/
++  virtual typename InputImageType::SizeType
++  GetRadius() const ITK_OVERRIDE
++  {
++    const InputImageType * input = this->GetInputImage();
++    if (!input)
++    {
++      itkExceptionMacro("Input image required!");
++    }
++    return input->GetLargestPossibleRegion().GetSize();
++  }
++
+ protected:
+   GaussianInterpolateImageFunction() {}
+   ~GaussianInterpolateImageFunction(){};
+-  void PrintSelf(std::ostream& os, Indent indent) const
++  void PrintSelf(std::ostream& os, Indent indent) const ITK_OVERRIDE
+     { this->Superclass::PrintSelf(os,indent); }
+ 
+ private:
+diff --git Submodules/c3d/itkextras/itkHessianToObjectnessMeasureImageFilter.h Submodules/c3d/itkextras/itkHessianToObjectnessMeasureImageFilter.h
+index 3e436f5..5ceafdc 100644
+--- Submodules/c3d/itkextras/itkHessianToObjectnessMeasureImageFilter.h
++++ Submodules/c3d/itkextras/itkHessianToObjectnessMeasureImageFilter.h
+@@ -132,9 +132,9 @@ class ITK_EXPORT HessianToObjectnessMeasureImageFilter:public
+ protected:
+   HessianToObjectnessMeasureImageFilter();
+   ~HessianToObjectnessMeasureImageFilter() {}
+-  void PrintSelf(std::ostream & os, Indent indent) const;
++  void PrintSelf(std::ostream & os, Indent indent) const ITK_OVERRIDE;
+ 
+-  void BeforeThreadedGenerateData(void);
++  void BeforeThreadedGenerateData(void) ITK_OVERRIDE;
+ 
+   void DynamicThreadedGenerateData(const OutputImageRegionType & outputRegionForThread) ITK_OVERRIDE;
+ 
+@@ -153,7 +153,7 @@ class ITK_EXPORT HessianToObjectnessMeasureImageFilter:public
+   struct AbsLessEqualCompare {
+     bool operator()(EigenValueType a, EigenValueType b)
+     {
+-      return vnl_math_abs(a) <= vnl_math_abs(b);
++      return abs(a) <= abs(b);
+     }
+   };
+ 
+diff --git Submodules/c3d/itkextras/itkHessianToObjectnessMeasureImageFilter.hxx Submodules/c3d/itkextras/itkHessianToObjectnessMeasureImageFilter.hxx
+index f6d8a52..bd7c92c 100644
+--- Submodules/c3d/itkextras/itkHessianToObjectnessMeasureImageFilter.hxx
++++ Submodules/c3d/itkextras/itkHessianToObjectnessMeasureImageFilter.hxx
+@@ -24,6 +24,7 @@
+ #include "itkProgressReporter.h"
+ 
+ #include "vnl/vnl_math.h"
++#include <cmath>
+ 
+ namespace itk
+ {
+@@ -109,7 +110,7 @@ HessianToObjectnessMeasureImageFilter< TInputImage, TOutputImage >
+     EigenValueArrayType sortedAbsEigenValues;
+     for ( unsigned int i = 0; i < ImageDimension; i++ )
+       {
+-      sortedAbsEigenValues[i] = vnl_math_abs(sortedEigenValues[i]);
++      sortedAbsEigenValues[i] = vnl_math::abs(sortedEigenValues[i]);
+       }
+ 
+     // initialize the objectness measure
+@@ -124,12 +125,12 @@ HessianToObjectnessMeasureImageFilter< TInputImage, TOutputImage >
+         {
+         rADenominatorBase *= sortedAbsEigenValues[j];
+         }
+-      if ( vcl_fabs(rADenominatorBase) > 0.0 )
++      if ( fabs(rADenominatorBase) > 0.0 )
+         {
+-        if ( vcl_fabs(m_Alpha) > 0.0 )
++        if ( fabs(m_Alpha) > 0.0 )
+           {
+-          rA /= vcl_pow( rADenominatorBase, 1.0 / ( ImageDimension - m_ObjectDimension - 1 ) );
+-          objectnessMeasure *= 1.0 - vcl_exp( -0.5 * vnl_math_sqr(rA) / vnl_math_sqr(m_Alpha) );
++          rA /= pow( rADenominatorBase, 1.0 / ( ImageDimension - m_ObjectDimension - 1 ) );
++          objectnessMeasure *= 1.0 - exp( -0.5 * vnl_math::sqr(rA) / vnl_math::sqr(m_Alpha) );
+           }
+         }
+       else
+@@ -146,11 +147,11 @@ HessianToObjectnessMeasureImageFilter< TInputImage, TOutputImage >
+         {
+         rBDenominatorBase *= sortedAbsEigenValues[j];
+         }
+-      if ( vcl_fabs(rBDenominatorBase) > 0.0 && vcl_fabs(m_Beta) > 0.0 )
++      if ( fabs(rBDenominatorBase) > 0.0 && fabs(m_Beta) > 0.0 )
+         {
+-        rB /= vcl_pow( rBDenominatorBase, 1.0 / ( ImageDimension - m_ObjectDimension ) );
++        rB /= pow( rBDenominatorBase, 1.0 / ( ImageDimension - m_ObjectDimension ) );
+ 
+-        objectnessMeasure *= vcl_exp( -0.5 * vnl_math_sqr(rB) / vnl_math_sqr(m_Beta) );
++        objectnessMeasure *= exp( -0.5 * vnl_math::sqr(rB) / vnl_math::sqr(m_Beta) );
+         }
+       else
+         {
+@@ -158,14 +159,14 @@ HessianToObjectnessMeasureImageFilter< TInputImage, TOutputImage >
+         }
+       }
+ 
+-    if ( vcl_fabs(m_Gamma) > 0.0 )
++    if ( fabs(m_Gamma) > 0.0 )
+       {
+       double frobeniusNormSquared = 0.0;
+       for ( unsigned int i = 0; i < ImageDimension; i++ )
+         {
+-        frobeniusNormSquared += vnl_math_sqr(sortedAbsEigenValues[i]);
++        frobeniusNormSquared += vnl_math::sqr(sortedAbsEigenValues[i]);
+         }
+-      objectnessMeasure *= 1.0 - vcl_exp( -0.5 * frobeniusNormSquared / vnl_math_sqr(m_Gamma) );
++      objectnessMeasure *= 1.0 - exp( -0.5 * frobeniusNormSquared / vnl_math::sqr(m_Gamma) );
+       }
+ 
+     // in case, scale by largest absolute eigenvalue
+diff --git Submodules/c3d/itkextras/itkLabelImageGaussianInterpolateImageFunction.h Submodules/c3d/itkextras/itkLabelImageGaussianInterpolateImageFunction.h
+index f26fc03..a910fe2 100644
+--- Submodules/c3d/itkextras/itkLabelImageGaussianInterpolateImageFunction.h
++++ Submodules/c3d/itkextras/itkLabelImageGaussianInterpolateImageFunction.h
+@@ -97,7 +97,7 @@ class ITK_EXPORT LabelImageGaussianInterpolateImageFunction :
+     }
+ 
+   /** Set input */
+-  virtual void SetInputImage(const TInputImage *img)
++  virtual void SetInputImage(const TInputImage *img) ITK_OVERRIDE
+     {
+     // Call parent method
+     Superclass::SetInputImage(img);
+@@ -124,7 +124,7 @@ class ITK_EXPORT LabelImageGaussianInterpolateImageFunction :
+    * ImageFunction::IsInsideBuffer() can be used to check bounds before
+    * calling the method. */
+   virtual OutputType EvaluateAtContinuousIndex( 
+-    const ContinuousIndexType & index ) const
++    const ContinuousIndexType & index ) const override
+     {
+       // The bound variables for x, y, z
+       int i0[VDim], i1[VDim];
+@@ -170,11 +170,11 @@ class ITK_EXPORT LabelImageGaussianInterpolateImageFunction :
+         
+         double wtest;
+         OutputType V = it.Get();
+-        WeightIter it = wm.find(V);
+-        if(it != wm.end())
++        WeightIter wit = wm.find(V);
++        if(wit != wm.end())
+           {
+-          it->second += w;
+-          wtest = it->second;
++          wit->second += w;
++          wtest = wit->second;
+           }
+         else
+           {
+@@ -194,10 +194,22 @@ class ITK_EXPORT LabelImageGaussianInterpolateImageFunction :
+       return vmax;
+     }
+ 
++  /** This is definition from ITKv4 Compatible mode. Change this in the future when needed*/
++  virtual typename InputImageType::SizeType
++  GetRadius() const ITK_OVERRIDE
++  {
++    const InputImageType * input = this->GetInputImage();
++    if (!input)
++    {
++      itkExceptionMacro("Input image required!");
++    }
++    return input->GetLargestPossibleRegion().GetSize();
++  }
++
+ protected:
+   LabelImageGaussianInterpolateImageFunction() {}
+   ~LabelImageGaussianInterpolateImageFunction(){};
+-  void PrintSelf(std::ostream& os, Indent indent) const
++  void PrintSelf(std::ostream& os, Indent indent) const ITK_OVERRIDE
+     { this->Superclass::PrintSelf(os,indent); }
+ 
+ private:
+diff --git Submodules/c3d/itkextras/itkLabelOverlapMeasuresImageFilter.h Submodules/c3d/itkextras/itkLabelOverlapMeasuresImageFilter.h
+index bb61805..ad59608 100644
+--- Submodules/c3d/itkextras/itkLabelOverlapMeasuresImageFilter.h
++++ Submodules/c3d/itkextras/itkLabelOverlapMeasuresImageFilter.h
+@@ -18,10 +18,10 @@
+ #define __itkLabelOverlapMeasuresImageFilter_h
+ 
+ #include "itkImageToImageFilter.h"
+-#include "itkFastMutexLock.h"
++#include <mutex>
+ #include "itkNumericTraits.h"
+ 
+-#include "itk_hash_map.h"
++#include <unordered_map>
+ 
+ namespace itk {
+ 
+@@ -100,7 +100,7 @@ class ITK_EXPORT LabelOverlapMeasuresImageFilter :
+     };
+ 
+   /** Type of the map used to store data per label */
+-  typedef hash_map<LabelType, LabelSetMeasures> MapType;
++  typedef std::unordered_map<LabelType, LabelSetMeasures> MapType;
+   typedef typename MapType::iterator MapIterator;
+   typedef typename MapType::const_iterator MapConstIterator;
+ 
+@@ -166,27 +166,27 @@ class ITK_EXPORT LabelOverlapMeasuresImageFilter :
+ protected:
+   LabelOverlapMeasuresImageFilter();
+   ~LabelOverlapMeasuresImageFilter(){};
+-  void PrintSelf( std::ostream& os, Indent indent ) const;
++  void PrintSelf( std::ostream& os, Indent indent ) const ITK_OVERRIDE;
+ 
+   /**
+    * Pass the input through unmodified. Do this by setting the output to the
+    * source this by setting the output to the source image in the
+    * AllocateOutputs() method.
+    */
+-  void AllocateOutputs();
++  void AllocateOutputs() ITK_OVERRIDE;
+ 
+-  void BeforeThreadedGenerateData();
++  void BeforeThreadedGenerateData() ITK_OVERRIDE;
+ 
+-  void AfterThreadedGenerateData();
++  void AfterThreadedGenerateData() ITK_OVERRIDE;
+ 
+   /** Multi-thread version GenerateData. */
+-  void ThreadedGenerateData( const RegionType&, int );
++  virtual void ThreadedGenerateData( const RegionType&, ThreadIdType ) ITK_OVERRIDE;
+ 
+   // Override since the filter needs all the data for the algorithm
+-  void GenerateInputRequestedRegion();
++  void GenerateInputRequestedRegion() ITK_OVERRIDE;
+ 
+   // Override since the filter produces all of its output
+-  void EnlargeOutputRequestedRegion( DataObject *data );
++  void EnlargeOutputRequestedRegion( DataObject *data ) ITK_OVERRIDE;
+ 
+ private:
+   LabelOverlapMeasuresImageFilter( const Self& ); //purposely not implemented
+@@ -195,7 +195,7 @@ class ITK_EXPORT LabelOverlapMeasuresImageFilter :
+   std::vector<MapType>                            m_LabelSetMeasuresPerThread;
+   MapType                                         m_LabelSetMeasures;
+ 
+-  SimpleFastMutexLock                             m_Mutex;
++  std::mutex                                      m_Mutex;
+ 
+ }; // end of class
+ 
+diff --git Submodules/c3d/itkextras/itkLabelOverlapMeasuresImageFilter.txx Submodules/c3d/itkextras/itkLabelOverlapMeasuresImageFilter.txx
+index c2af626..d64a0c8 100644
+--- Submodules/c3d/itkextras/itkLabelOverlapMeasuresImageFilter.txx
++++ Submodules/c3d/itkextras/itkLabelOverlapMeasuresImageFilter.txx
+@@ -26,8 +26,8 @@ namespace itk {
+ 
+ #if defined(__GNUC__) && (__GNUC__ <= 2) //NOTE: This class needs a mutex for gnu 2.95
+ /** Used for mutex locking */
+-#define LOCK_HASHMAP this->m_Mutex.Lock()
+-#define UNLOCK_HASHMAP this->m_Mutex.Unlock()
++#define LOCK_HASHMAP this->m_Mutex.lock()
++#define UNLOCK_HASHMAP this->m_Mutex.unlock()
+ #else
+ #define LOCK_HASHMAP
+ #define UNLOCK_HASHMAP
+@@ -90,7 +90,7 @@ void
+ LabelOverlapMeasuresImageFilter<TLabelImage>
+ ::BeforeThreadedGenerateData()
+ {
+-  int numberOfThreads = this->GetNumberOfThreads();
++  int numberOfThreads = this->GetNumberOfWorkUnits();
+ 
+   // Resize the thread temporaries
+   this->m_LabelSetMeasuresPerThread.resize( numberOfThreads );
+@@ -111,7 +111,7 @@ LabelOverlapMeasuresImageFilter<TLabelImage>
+ ::AfterThreadedGenerateData()
+ {
+   // Run through the map for each thread and accumulate the set measures.
+-  for( int n = 0; n < this->GetNumberOfThreads(); n++ )
++  for( int n = 0; n < this->GetNumberOfWorkUnits(); n++ )
+     {
+     // iterate over the map for this thread
+     for( MapConstIterator threadIt = this->m_LabelSetMeasuresPerThread[n].begin();
+@@ -146,7 +146,7 @@ template<class TLabelImage>
+ void
+ LabelOverlapMeasuresImageFilter<TLabelImage>
+ ::ThreadedGenerateData( const RegionType& outputRegionForThread,
+-  int threadId )
++  ThreadIdType threadId )
+ {
+   ImageRegionConstIterator<LabelImageType> ItS( this->GetSourceImage(),
+     outputRegionForThread );
+diff --git Submodules/c3d/itkextras/itkMultiScaleHessianBasedMeasureImageFilter.hxx Submodules/c3d/itkextras/itkMultiScaleHessianBasedMeasureImageFilter.hxx
+index 1af5faf..39dee46 100644
+--- Submodules/c3d/itkextras/itkMultiScaleHessianBasedMeasureImageFilter.hxx
++++ Submodules/c3d/itkextras/itkMultiScaleHessianBasedMeasureImageFilter.hxx
+@@ -21,6 +21,7 @@
+ #include "itkMultiScaleHessianBasedMeasureImageFilter.h"
+ #include "itkImageRegionIterator.h"
+ #include "vnl/vnl_math.h"
++#include <cmath>
+ 
+ /*
+  *
+@@ -342,15 +343,15 @@ MultiScaleHessianBasedMeasureImageFilter
+     {
+     case Self::EquispacedSigmaSteps:
+       {
+-      const double stepSize = vnl_math_max( 1e-10, ( m_SigmaMaximum - m_SigmaMinimum ) / ( m_NumberOfSigmaSteps - 1 ) );
++      const double stepSize = vnl_math::max( 1e-10, ( m_SigmaMaximum - m_SigmaMinimum ) / ( m_NumberOfSigmaSteps - 1 ) );
+       sigmaValue = m_SigmaMinimum + stepSize * scaleLevel;
+       break;
+       }
+     case Self::LogarithmicSigmaSteps:
+       {
+       const double stepSize =
+-        vnl_math_max( 1e-10, ( vcl_log(m_SigmaMaximum) - vcl_log(m_SigmaMinimum) ) / ( m_NumberOfSigmaSteps - 1 ) );
+-      sigmaValue = vcl_exp(vcl_log (m_SigmaMinimum) + stepSize * scaleLevel);
++        vnl_math::max( 1e-10, ( log(m_SigmaMaximum) - log(m_SigmaMinimum) ) / ( m_NumberOfSigmaSteps - 1 ) );
++      sigmaValue = exp(log (m_SigmaMinimum) + stepSize * scaleLevel);
+       break;
+       }
+     default:
+diff --git Submodules/c3d/utilities/AffineTransformTool.cxx Submodules/c3d/utilities/AffineTransformTool.cxx
+index 4c3d0a8..0558b60 100644
+--- Submodules/c3d/utilities/AffineTransformTool.cxx
++++ Submodules/c3d/utilities/AffineTransformTool.cxx
+@@ -221,7 +221,7 @@ void quart_print(MatrixType &mat )
+ 
+ 
+   // QR decomposition
+-  vnl_qr<double> qr(A);
++  vnl_qr<double> qr(A.as_matrix());
+   vnl_matrix_fixed<double, 3, 3> m = qr.Q(), R = qr.R(), F;
+ 
+   F.set_identity();
+@@ -350,7 +350,7 @@ void irtk_write(MatrixStack &vmat, const char *fname)
+   Mat33 A = M.extract(3,3);
+   
+   // QR decomposition
+-  vnl_qr<double> qr(A);
++  vnl_qr<double> qr(A.as_matrix());
+   Mat33 Q = qr.Q(), R = qr.R();
+ 
+   // Compute the flip matrix so that the scales are positive
+

--- a/easyconfigs/i/ITK-SNAP/ITK-SNAP-4.2.0-foss-2023a.eb
+++ b/easyconfigs/i/ITK-SNAP/ITK-SNAP-4.2.0-foss-2023a.eb
@@ -1,0 +1,50 @@
+#This easyconfig is "Work in Progress". The combination of libraries did not work for v3.8.0
+# but may work for the upcoming 4.0.0 release.
+easyblock = 'CMakeMake'
+
+name = 'ITK-SNAP'
+version = '4.2.0'
+
+homepage = 'http://www.itksnap.org/'
+description = """ITK-SNAP is a software application used to segment structures in 3D medical images. It is the product of a decade-long collaboration between Paul Yushkevich, Ph.D., of the Penn Image Computing and Science Laboratory (PICSL) at the University of Pennsylvania, and Guido Gerig, Ph.D., of the Scientific Computing and Imaging Institute (SCI) at the University of Utah, whose vision was to create a tool that would be dedicated to a specific function, segmentation, and would be easy to use and learn. ITK-SNAP is free, open-source, and multi-platform."""
+
+toolchain = {'name': 'foss', 'version': '2023a'}
+toolchainopts = {'pic': True}
+
+#github_account = 'pyushkevich'
+
+sources = [
+  {
+  'filename': 'v%(version)s.tar.gz',
+  'git_config': {
+    'url': 'https://github.com/Neves-P',
+    'repo_name': 'itksnap',
+    'commit': '12218c7',
+    'keep_git_dir': True,
+    'recursive': True,
+  },
+}]
+
+patches = ['ITK-SNAP-4.2.0-c3d.patch']
+
+builddependencies = [
+    ('CMake', '3.26.3'),
+]
+
+dependencies = [
+    ('ITK', '5.3.0', '-extramodule'),
+    ('VTK', '9.3.0', '-GUISupportQt'),
+    ('Qt6', '6.5.2'),
+    ('Eigen', '3.4.0'),
+]
+
+separate_build_dir = True
+
+
+configopts = '-DBUILD_SHARED_LIBS=ON -DBUILD_TESTING=ON -DENABLE_PRECOMPILED_HEADERS=OFF '
+configopts += '-DITK_DIR=$EBROOTITK -DVTK_DIR=$EBROOTVTK '
+configopts += '-DCMAKE_PREFIX_PATH=$EBROOTQT6/bin/qmake '
+
+moduleclass = 'vis'
+
+

--- a/easyconfigs/i/ITK/ITK-5.2.1-foss-2023a-extramodule.eb
+++ b/easyconfigs/i/ITK/ITK-5.2.1-foss-2023a-extramodule.eb
@@ -1,0 +1,71 @@
+# Contributors:
+# Fenglai Liu (fenglai@accre.vanderbilt.edu) - Vanderbilt University
+# Alex Domingo (alex.domingo.toro@vub.be) - Vrije Universiteit Brussel (VUB)
+# Denis Kristak (INUITS)
+#
+easyblock = 'CMakeMake'
+
+name = 'ITK'
+version = '5.2.1'
+versionsuffix = '-extramodule'
+
+homepage = 'https://itk.org'
+description = """Insight Segmentation and Registration Toolkit (ITK) provides
+ an extensive suite of software tools for registering and segmenting
+ multidimensional imaging data."""
+
+toolchain = {'name': 'foss', 'version': '2023a'}
+toolchainopts = {'pic': True, 'cstd': 'c++11'}
+
+github_account = 'InsightSoftwareConsortium'
+source_urls = [GITHUB_SOURCE]
+sources = ['v%(version)s.tar.gz']
+patches = ['ITK-5.2.1_allow_legacy_with_wrapping.patch']
+
+builddependencies = [
+    ('CMake', '3.26.3'),
+    ('Bison', '3.8.2'),
+    ('Eigen', '3.4.0'),
+    ('SWIG', '4.1.1'),
+    ('Perl', '5.36.1'),
+]
+dependencies = [
+    ('Python', '3.11.3'),
+    ('double-conversion', '3.3.0'),
+    ('expat', '2.5.0'),
+    ('HDF5', '1.14.0'),
+    ('libjpeg-turbo', '2.1.5.1'),
+    ('libpng', '1.6.39'),
+    ('LibTIFF', '4.5.0'),
+    ('VTK', '9.3.0', '-GUISupportQt'),
+    ('zlib', '1.2.13'),
+]
+
+# Features
+configopts = '-DBUILD_SHARED_LIBS=ON -DBUILD_TESTING=OFF '
+configopts += '-DModule_ITKReview=ON -DModule_ITKVtkGlue=ON -DModule_SimpleITKFilters=ON -DModule_MorphologicalContourInterpolation=ON '
+# Enable Python bindings
+configopts += '-DITK_WRAP_PYTHON:BOOL=ON -DPython3_EXECUTABLE=$EBROOTPYTHON/bin/python '
+configopts += '-DSWIG_EXECUTABLE=$EBROOTSWIG/bin/swig -DSWIG_DIR=$EBROOTSWIG '
+configopts += '-DPY_SITE_PACKAGES_PATH=%(installdir)s/lib/python%(pyshortver)s/site-packages '
+# Dependencies from EB
+local_sys_deps = ['DOUBLECONVERSION', 'EIGEN', 'EXPAT', 'FFTW', 'HDF5', 'JPEG', 'PNG', 'SWIG', 'TIFF', 'ZLIB']
+local_sys_cmake = ['-DITK_USE_SYSTEM_%s=ON' % d for d in local_sys_deps]
+configopts += ' '.join(local_sys_cmake)
+
+prebuildopts = "LC_ALL=C "
+
+local_lib_names = ['ITKCommon', 'ITKIOHDF5', 'ITKIOJPEG', 'ITKIOPNG', 'ITKIOTIFF',
+                   'ITKReview', 'ITKVTK', 'ITKVtkGlue', 'itkSimpleITKFilters']
+
+sanity_check_paths = {
+    'files': ['bin/itkTestDriver'] +
+             ['lib/lib%s-%%(version_major)s.%%(version_minor)s.%s' % (l, SHLIB_EXT) for l in local_lib_names],
+    'dirs': ['include/ITK-%(version_major)s.%(version_minor)s', 'lib/python%(pyshortver)s/site-packages', 'share'],
+}
+
+sanity_check_commands = ["python -c 'import itk'"]
+
+modextrapaths = {'PYTHONPATH': 'lib/python%(pyshortver)s/site-packages'}
+
+moduleclass = 'data'

--- a/easyconfigs/v/VTK/VTK-9.3.0-foss-2023a-GUISupportQt.eb
+++ b/easyconfigs/v/VTK/VTK-9.3.0-foss-2023a-GUISupportQt.eb
@@ -1,0 +1,101 @@
+##
+# Authors::
+# * Fotis Georgatos <fotis@cern.ch>
+# * Robert Mijakovic <robert.mijakovic@lxp.lu>
+##
+
+easyblock = 'CMakeNinja'
+
+name = 'VTK'
+version = '9.3.0'
+versionsuffix = '-GUISupportQt'
+
+homepage = 'https://www.vtk.org'
+description = """The Visualization Toolkit (VTK) is an open-source, freely available software system for
+ 3D computer graphics, image processing and visualization. VTK consists of a C++ class library and several
+ interpreted interface layers including Tcl/Tk, Java, and Python. VTK supports a wide variety of visualization
+ algorithms including: scalar, vector, tensor, texture, and volumetric methods; and advanced modeling techniques
+ such as: implicit modeling, polygon reduction, mesh smoothing, cutting, contouring, and Delaunay triangulation."""
+
+toolchain = {'name': 'foss', 'version': '2023a'}
+toolchainopts = {'usempi': True}
+
+source_urls = ['https://www.vtk.org/files/release/%(version_major_minor)s']
+sources = [
+    SOURCE_TAR_GZ,
+    '%(name)sData-%(version)s.tar.gz',
+]
+patches = [('vtk-version.egg-info', '.')]
+checksums = [
+    {'VTK-9.3.0.tar.gz': 'fdc7b9295225b34e4fdddc49cd06e66e94260cb00efee456e0f66568c9681be9'},
+    {'VTKData-9.3.0.tar.gz': 'f82142dd327e995c9536c1003e1370bb4092c96f23edb8119d16d2411ef35dc3'},
+    {'vtk-version.egg-info': '787b82415ae7a4a1f815b4db0e25f7abc809a05fc85d7d219627f3a7e5d3867b'},
+]
+
+builddependencies = [
+    ('CMake', '3.26.3'),
+    ('Ninja', '1.11.1'),
+]
+
+dependencies = [
+    ('Python', '3.11.3'),
+    ('SciPy-bundle', '2023.07'),
+    ('XZ', '5.4.2'),
+    ('libGLU', '9.0.3'),
+    ('X11', '20230603'),
+    ('Qt6', '6.5.2'),
+]
+
+separate_build_dir = True
+
+# OpenGL
+configopts = "-DOPENGL_glu_LIBRARY=$EBROOTLIBGLU/lib/libGLU.%s " % SHLIB_EXT
+configopts += "-DOPENGL_gl_LIBRARY=$EBROOTMESA/lib/libGL.%s " % SHLIB_EXT
+configopts += "-DOPENGL_INCLUDE_DIR=$EBROOTMESA/include "
+# Python
+configopts += "-DVTK_WRAP_PYTHON=ON -DVTK_PYTHON_VERSION=3 -DVTK_PYTHON_OPTIONAL_LINK=OFF "
+configopts += "-DPython3_EXECUTABLE=$EBROOTPYTHON/bin/python3 "
+configopts += "-DPython3_INCLUDE_DIR=$EBROOTPYTHON/include/python%(pyshortver)s "
+configopts += "-DPython3_LIBRARY=$EBROOTPYTHON/lib/libpython%(pyshortver)s.so "
+# Other
+configopts += "-DVTK_USE_MPI=ON "
+configopts += "-DCMAKE_INSTALL_LIBDIR=lib "
+configopts += "-DVTK_GROUP_ENABLE_Qt=YES "
+configopts += "-DVTK_Qt_VERSION=6 "
+configopts += "-DQt_QMAKE_EXECUTABLE=$EBROOTQT6/bin/qmake "
+#configopts += "-DVTK_MODULE_ENABLE_VTK_GUISupportQt=YES "
+configopts += "-DVTK_MODULE_ENABLE_VTK_GUISupportQuick=NO "
+configopts += "-DVTK_MODULE_ENABLE_VTK_GUISupportQtSQL=NO "
+configopts += "-DVTK_REQUIRED_OBJCXX_FLAGS=''" 
+
+preinstallopts = "export PYTHONPATH=%(installdir)s/lib/python%(pyshortver)s/site-packages:$PYTHONPATH && "
+
+# Install a egg-info file so VTK is more python friendly, required for mayavi
+local_egg_info_src = '%(builddir)s/VTK-%(version)s/vtk-version.egg-info'
+local_egg_info_dest = '%(installdir)s/lib/python%(pyshortver)s/site-packages/vtk-%(version)s.egg-info'
+postinstallcmds = [
+    'sed "s/#VTK_VERSION#/%%(version)s/" %s > %s' % (local_egg_info_src, local_egg_info_dest),
+]
+
+modextrapaths = {'PYTHONPATH': ['lib/python%(pyshortver)s/site-packages']}
+
+local_vtk_exec = ['vtk%s-%%(version_major_minor)s' % x
+                  for x in ['WrapJava', 'ParseJava', 'WrapPythonInit', 'WrapPython', 'WrapHierarchy']]
+local_vtk_exec += ['vtkpython']
+local_vtk_libs = ['CommonCore', 'IONetCDF', 'ParallelCore', 'RenderingOpenGL2']
+
+sanity_check_paths = {
+    'files': ['bin/%s' % x for x in local_vtk_exec] + ['include/vtk-%(version_major_minor)s/vtkMPI.h'] +
+             ['lib/libvtk%s-%%(version_major_minor)s.%s' % (l, SHLIB_EXT) for l in local_vtk_libs],
+    'dirs': ['lib/python%(pyshortver)s/site-packages/', 'include/vtk-%(version_major_minor)s'],
+}
+
+sanity_check_commands = [
+    "python -c 'import %(namelower)s'",
+    "python -c 'import pkg_resources; pkg_resources.get_distribution(\"vtk\")'",
+    # make sure that VTK Python libraries link to libpython (controlled via DVTK_PYTHON_OPTIONAL_LINK=OFF),
+    # see https://gitlab.kitware.com/vtk/vtk/-/issues/17881
+    "ldd $EBROOTVTK/lib/libvtkPythonContext2D-%%(version_major_minor)s.%s | grep /libpython" % SHLIB_EXT,
+]
+
+moduleclass = 'vis'


### PR DESCRIPTION
Opening this PR to keep track of progress when building ITK-SNAP.

As of now, I tried using a newer toolchain, for which we have all the dependencies available already, but the build fails.

```
== 2024-05-16 14:37:32,488 build_log.py:171 ERROR EasyBuild crashed with an error (at easybuild/base/exceptions.py:126 in __init__): cmd " cmake  -DCMAKE_INSTALL_PREFIX=/home1/f115372/.local/easybuild/software/ITK-SNAP/4.0.0-foss-2022b -DCMAKE_BUILD_TYPE=Release -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_POLICY_DEFAULT_CMP0094=NEW -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_FIND_USE_PACKAGE_REGISTRY=OFF -DBUILD_SHARED_LIBS=ON -DBUILD_TESTING=ON -DENABLE_PRECOMPILED_HEADERS=OFF -DITK_DIR=$EBROOTITK -DVTK_DIR=$EBROOTVTK -DCMAKE_PREFIX_PATH=$EBROOTQT5/lib/cmake  /home1/f115372/.local/easybuild/build/ITKSNAP/4.0.0/foss-2022b/itksnap/" exited with exit code 1 and output:
-- The C compiler identification is GNU 12.2.0
-- The CXX compiler identification is GNU 12.2.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /cvmfs/hpc.rug.nl/versions/2023.01/rocky8/x86_64/amd/zen3/software/GCCcore/12.2.0/bin/gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /cvmfs/hpc.rug.nl/versions/2023.01/rocky8/x86_64/amd/zen3/software/GCCcore/12.2.0/bin/g++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- ITK-SNAP Git Info:
CMake Deprecation Warning at CMakeLists.txt:16 (cmake_policy):
  The OLD behavior for policy CMP0026 will be removed from a future version
  of CMake.

  The cmake-policies(7) manual explains that the OLD behaviors of all
  policies are deprecated and that a policy should be set to OLD only under
  specific short-term circumstances.  Projects should be ported to the NEW
  behavior and not rely on setting a policy to OLD.


-- ITK-SNAP Git Info:
--   Branch : HEAD
--   SHA    : 7a104c25401ce23599dc8d32ea80f3daae80f379
--   Date   : 2019-06-12 06:53:09 -0400
-- Found HDF5: /cvmfs/hpc.rug.nl/versions/2023.01/rocky8/x86_64/amd/zen3/software/HDF5/1.14.0-gompi-2022b/lib/libhdf5_cpp.so;/cvmfs/hpc.rug.nl/versions/2023.01/rocky8/x86_64/amd/zen3/software/HDF5/1.14.0-gompi-2022b/lib/libhdf5.so;/usr/lib64/libpthread.so;/cvmfs/hpc.rug.nl/versions/2023.01/rocky8/x86_64/amd/zen3/software/Szip/2.1.1-GCCcore-12.2.0/lib/libsz.so;/cvmfs/hpc.rug.nl/versions/2023.01/rocky8/x86_64/amd/zen3/software/zlib/1.2.12-GCCcore-12.2.0/lib/libz.so;/usr/lib64/libdl.so;/usr/lib64/libm.so;/usr/lib64/libm.so;/usr/lib64/libpthread.so;/cvmfs/hpc.rug.nl/versions/2023.01/rocky8/x86_64/amd/zen3/software/HDF5/1.14.0-gompi-2022b/lib/libhdf5.so;/usr/lib64/libpthread.so;/cvmfs/hpc.rug.nl/versions/2023.01/rocky8/x86_64/amd/zen3/software/Szip/2.1.1-GCCcore-12.2.0/lib/libsz.so;/cvmfs/hpc.rug.nl/versions/2023.01/rocky8/x86_64/amd/zen3/software/zlib/1.2.12-GCCcore-12.2.0/lib/libz.so;/usr/lib64/libdl.so;/usr/lib64/libm.so;/usr/lib64/libm.so;/usr/lib64/libpthread.so (found version "1.14.0") found components: CXX C
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE
-- Found OpenGL: /cvmfs/hpc.rug.nl/versions/2023.01/rocky8/x86_64/amd/zen3/software/libglvnd/1.6.0-GCCcore-12.2.0/lib/libOpenGL.so  found components: OpenGL GLX
-- Found Python3: /cvmfs/hpc.rug.nl/versions/2023.01/rocky8/x86_64/amd/zen3/software/Python/3.10.8-GCCcore-12.2.0/bin/python3.10 (found suitable version "3.10.8", minimum required is "3.10") found components: Interpreter Development.Module Development.Embed
-- Found MPI_C: /cvmfs/hpc.rug.nl/versions/2023.01/rocky8/x86_64/amd/zen3/software/OpenMPI/4.1.4-GCC-12.2.0/lib/libmpi.so (found version "3.1")
-- Found MPI: TRUE (found version "3.1") found components: C
-- Found X11: /cvmfs/hpc.rug.nl/versions/2023.01/rocky8/x86_64/amd/zen3/software/X11/20221110-GCCcore-12.2.0/include
-- Looking for XOpenDisplay in /cvmfs/hpc.rug.nl/versions/2023.01/rocky8/x86_64/amd/zen3/software/X11/20221110-GCCcore-12.2.0/lib/libX11.so;/cvmfs/hpc.rug.nl/versions/2023.01/rocky8/x86_64/amd/zen3/software/X11/20221110-GCCcore-12.2.0/lib/libXext.so
-- Looking for XOpenDisplay in /cvmfs/hpc.rug.nl/versions/2023.01/rocky8/x86_64/amd/zen3/software/X11/20221110-GCCcore-12.2.0/lib/libX11.so;/cvmfs/hpc.rug.nl/versions/2023.01/rocky8/x86_64/amd/zen3/software/X11/20221110-GCCcore-12.2.0/lib/libXext.so - found
-- Looking for gethostbyname
-- Looking for gethostbyname - found
-- Looking for connect
-- Looking for connect - found
-- Looking for remove
-- Looking for remove - found
-- Looking for shmat
-- Looking for shmat - found
-- Looking for IceConnectionNumber in ICE
-- Looking for IceConnectionNumber in ICE - found
CMake Deprecation Warning at /cvmfs/hpc.rug.nl/versions/2023.01/rocky8/x86_64/amd/zen3/software/VTK/9.2.6-foss-2022b/lib64/cmake/vtk-9.2/vtk-use-file-deprecated.cmake:1 (message):
  The `VTK_USE_FILE` is no longer used starting with 8.90.
Call Stack (most recent call first):
  CMake/standalone.cmake:11 (INCLUDE)
  CMakeLists.txt:153 (INCLUDE)


-- Found OpenGL: /cvmfs/hpc.rug.nl/versions/2023.01/rocky8/x86_64/amd/zen3/software/libglvnd/1.6.0-GCCcore-12.2.0/lib/libOpenGL.so
-- Found CURL: /cvmfs/hpc.rug.nl/versions/2023.01/rocky8/x86_64/amd/zen3/software/cURL/7.86.0-GCCcore-12.2.0/lib/libcurl.so (found version "7.86.0")
CMake Warning (dev) at Submodules/c3d/CMakeLists.txt:14 (OPTION):
  Policy CMP0077 is not set: option() honors normal variables.  Run "cmake
  --help-policy CMP0077" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.

  For compatibility with older versions of CMake, option is clearing the
  normal variable 'CONVERT3D_BUILD_AS_SUBPROJECT'.
This warning is for project developers.  Use -Wno-dev to suppress it.

--    CPACK_SYSTEM_NAME Linux-x86_64
--    CPACK_PACKAGE_FILE_NAME c3d-1.1.0-Linux-x86_64
-- GREEDY Version: 1.0.1 Released Mar 21, 2019
-- GIT Info:
--   Branch : HEAD
--   SHA    : 79e69e3d7b4d1e88cf87218ca99d6d373d323f9f
--   Date   : 2019-03-21 13:41:18 -0400
CMake Warning (dev) at Submodules/greedy/CMakeLists.txt:20 (OPTION):
  Policy CMP0077 is not set: option() honors normal variables.  Run "cmake
  --help-policy CMP0077" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.

  For compatibility with older versions of CMake, option is clearing the
  normal variable 'GREEDY_BUILD_AS_SUBPROJECT'.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at /cvmfs/hpc.rug.nl/versions/2023.01/rocky8/x86_64/amd/zen3/software/CMake/3.24.3-GCCcore-12.2.0/share/cmake-3.24/Modules/BundleUtilities.cmake:237 (message):
  Policy CMP0080 is not set: BundleUtilities cannot be included at configure
  time.  Run "cmake --help-policy CMP0080" for policy details.  Use the
  cmake_policy command to set the policy and suppress this warning.

Call Stack (most recent call first):
  /cvmfs/hpc.rug.nl/versions/2023.01/rocky8/x86_64/amd/zen3/software/CMake/3.24.3-GCCcore-12.2.0/share/cmake-3.24/Modules/BundleUtilities.cmake:246 (_warn_cmp0080)
  CMakeLists.txt:1160 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.

-- === Installation Section ===
--    CMAKE_SYSTEM_PROCESSOR x86_64
--    CMAKE_SYSTEM_NAME Linux
CMake Warning (dev) at /cvmfs/hpc.rug.nl/versions/2023.01/rocky8/x86_64/amd/zen3/software/CMake/3.24.3-GCCcore-12.2.0/share/cmake-3.24/Modules/BundleUtilities.cmake:237 (message):
  Policy CMP0080 is not set: BundleUtilities cannot be included at configure
  time.  Run "cmake --help-policy CMP0080" for policy details.  Use the
  cmake_policy command to set the policy and suppress this warning.

Call Stack (most recent call first):
  /cvmfs/hpc.rug.nl/versions/2023.01/rocky8/x86_64/amd/zen3/software/CMake/3.24.3-GCCcore-12.2.0/share/cmake-3.24/Modules/BundleUtilities.cmake:246 (_warn_cmp0080)
  CMake/DeployQt5.cmake:114 (include)
  CMakeLists.txt:1476 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Error at CMakeLists.txt:1487 (get_property):
  get_property could not find TARGET Qt5::QXcbEglIntegrationPlugin.  Perhaps
  it has not yet been created.


-- Configuring incomplete, errors occurred!
```

It seems like we actually get further in the build with `foss/2021b`.