### PR TITLE
Add rclone-1.66.0 to easystack

### DIFF
--- a/easystacks/habrok-2023.01-cvmfs.yml
+++ b/easystacks/habrok-2023.01-cvmfs.yml
@@ -409,3 +409,4 @@ easyconfigs:
   - QuantumESPRESSO-7.3.1-foss-2023a.eb
   - MUSCLE-3.8.31-GCCcore-11.2.0.eb
   - SAMtools-0.1.19-GCC-10.3.0.eb
+  - rclone-1.66.0.eb


### PR DESCRIPTION
Adds `rclone` for data transfer to google drive and for possible integration with the web portal.