### PR TITLE
Add Flye, Racon GCCcore 13.2.0 and Nextflow

### DIFF
--- a/easystacks/habrok-2023.01-cvmfs-generic.yml
+++ b/easystacks/habrok-2023.01-cvmfs-generic.yml
@@ -9,4 +9,4 @@ easyconfigs:
   - StataSE-18.eb:
       options:
         ignore-osdeps: True
-
+  - Nextflow-24.04.2.eb

--- a/easystacks/habrok-2023.01-cvmfs.yml
+++ b/easystacks/habrok-2023.01-cvmfs.yml
@@ -416,3 +416,5 @@ easyconfigs:
   - CREST-3.0.2-gfbf-2023b.eb:
       options:
         from-pr: 21548
+  - Racon-1.5.0-GCCcore-13.2.0.eb
+  - Flye-2.9.4-GCC-13.2.0.eb


### PR DESCRIPTION
Still need to add `Nextflow` to cvmfs generic stack. From I2410-01336